### PR TITLE
[Add] TextInputContainer, RegisterNicknameView, View extension

### DIFF
--- a/BE.xcodeproj/project.pbxproj
+++ b/BE.xcodeproj/project.pbxproj
@@ -7,6 +7,9 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		7A3DF798287029FD00CCC81A /* TextInputContainer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7A3DF797287029FD00CCC81A /* TextInputContainer.swift */; };
+		7A3DF79A28702D0500CCC81A /* RegisterNicknameView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7A3DF79928702D0400CCC81A /* RegisterNicknameView.swift */; };
+		7A3DF79C2870308100CCC81A /* View.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7A3DF79B2870308100CCC81A /* View.swift */; };
 		C089031D2870225800359264 /* Constant.swift in Sources */ = {isa = PBXBuildFile; fileRef = C089031C2870225800359264 /* Constant.swift */; };
 		C08903202870228D00359264 /* LoginManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = C089031F2870228D00359264 /* LoginManager.swift */; };
 		C08903232870230C00359264 /* String.swift in Sources */ = {isa = PBXBuildFile; fileRef = C08903222870230C00359264 /* String.swift */; };
@@ -23,6 +26,9 @@
 /* Begin PBXFileReference section */
 		6AC41999BD864A6334FDBEAA /* Pods-BE.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-BE.release.xcconfig"; path = "Target Support Files/Pods-BE/Pods-BE.release.xcconfig"; sourceTree = "<group>"; };
 		7183E9D455D84C6700905EBA /* Pods_BE.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_BE.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		7A3DF797287029FD00CCC81A /* TextInputContainer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TextInputContainer.swift; sourceTree = "<group>"; };
+		7A3DF79928702D0400CCC81A /* RegisterNicknameView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RegisterNicknameView.swift; sourceTree = "<group>"; };
+		7A3DF79B2870308100CCC81A /* View.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = View.swift; sourceTree = "<group>"; };
 		C089031C2870225800359264 /* Constant.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Constant.swift; sourceTree = "<group>"; };
 		C089031F2870228D00359264 /* LoginManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoginManager.swift; sourceTree = "<group>"; };
 		C08903222870230C00359264 /* String.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = String.swift; sourceTree = "<group>"; };
@@ -79,6 +85,7 @@
 			isa = PBXGroup;
 			children = (
 				C08903222870230C00359264 /* String.swift */,
+				7A3DF79B2870308100CCC81A /* View.swift */,
 			);
 			path = Extension;
 			sourceTree = "<group>";
@@ -88,6 +95,7 @@
 			children = (
 				C089031B2870223000359264 /* Components */,
 				C0E0B0CD287013BC0081DD1F /* ContentView.swift */,
+				7A3DF79928702D0400CCC81A /* RegisterNicknameView.swift */,
 			);
 			path = Source;
 			sourceTree = "<group>";
@@ -96,6 +104,7 @@
 			isa = PBXGroup;
 			children = (
 				C08903262870233500359264 /* DummyView.swift */,
+				7A3DF797287029FD00CCC81A /* TextInputContainer.swift */,
 			);
 			path = Components;
 			sourceTree = "<group>";
@@ -274,7 +283,10 @@
 			files = (
 				C08903252870231D00359264 /* DummyModel.swift in Sources */,
 				C0E0B0CE287013BC0081DD1F /* ContentView.swift in Sources */,
+				7A3DF79C2870308100CCC81A /* View.swift in Sources */,
 				C08903272870233500359264 /* DummyView.swift in Sources */,
+				7A3DF798287029FD00CCC81A /* TextInputContainer.swift in Sources */,
+				7A3DF79A28702D0500CCC81A /* RegisterNicknameView.swift in Sources */,
 				C08903202870228D00359264 /* LoginManager.swift in Sources */,
 				C08903232870230C00359264 /* String.swift in Sources */,
 				C0E0B0CC287013BC0081DD1F /* BEApp.swift in Sources */,

--- a/BE/Source/Components/TextInputContainer.swift
+++ b/BE/Source/Components/TextInputContainer.swift
@@ -1,0 +1,67 @@
+//
+//  TextInputContainer.swift
+//  BE
+//
+//  Created by Noah's Ark on 2022/07/02.
+//
+//  TextInputContainer는 닉네임, 전화번호 등 회원가입 시 텍스트를 입력받습니다.
+
+import SwiftUI
+
+struct TextInputContainer: View {
+    
+    let title: String
+    let placeholder: String
+    let keyboardType: UIKeyboardType
+    
+    @Binding var description: String
+    @Binding var isCompleted: Bool
+    
+    var body: some View {
+        VStack {
+            ZStack {
+                VStack (alignment: .leading) {
+                    // 닉네임, 전화번호 등 타이틀을 설정합니다.
+                    Text(title)
+                        .foregroundColor(.red)
+                        .font(.system(size: 16, weight: .medium))
+                    
+                    // 사용자의 텍스트를 입력받습니다.
+                    TextField("", text: $description)
+                        .keyboardType(keyboardType)
+                        .font(.system(size: 22, weight: .regular))
+                        .placeholder(when: description.isEmpty) {
+                            Text(placeholder)
+                                .foregroundColor(.blue)
+                        }
+                        .onSubmit {
+                            self.isCompleted = true
+                        }
+                }
+                .padding(.leading, 14)
+                .padding(.vertical, 15)
+            }// ZStack
+            .background(.gray)
+            .cornerRadius(12)
+        }// VStack
+        .padding(.horizontal, 20)
+        
+        
+    }// body
+}// TextInputContainer
+
+struct TextInputContainer_Previews: PreviewProvider {
+    
+    @State static var description = "01023456789"
+    @State static var isCompleted = false
+    
+    static var previews: some View {
+        TextInputContainer(
+            title: "Phone Number",
+            placeholder: "Please type your phonenumber.",
+            keyboardType: .numberPad,
+            description: $description,
+            isCompleted: $isCompleted
+        )
+    }
+}

--- a/BE/Source/RegisterNicknameView.swift
+++ b/BE/Source/RegisterNicknameView.swift
@@ -1,0 +1,53 @@
+//
+//  RegisterNicknameView.swift
+//  BE
+//
+//  Created by Noah's Ark on 2022/07/02.
+//
+
+import SwiftUI
+
+struct RegisterNicknameView: View {
+    
+    let title: String = "닉네임"
+    let placeholder: String = "닉네임을 입력해주세요"
+    
+    @State var descripton: String = ""
+    @State var isCompleted: Bool = false
+    
+    var body: some View {
+        NavigationView {
+            VStack {
+                HStack {
+                    Text("반가워요\n아카데미 닉네임이 어떻게 되시나요?")
+                        .font(.system(size: 22, weight: .bold))
+                        .multilineTextAlignment(.leading)
+                    
+                    Spacer()
+                }
+                .padding(.horizontal, 20)
+                
+                TextInputContainer(
+                    title: title,
+                    placeholder: placeholder,
+                    keyboardType: .default,
+                    description: $descripton,
+                    isCompleted: $isCompleted
+                )
+
+                Spacer()
+
+                NavigationLink(destination: ContentView(), isActive: $isCompleted) {
+                    EmptyView()
+                }
+            }
+
+        }// NavigationView
+    }// body
+}// RegisterNicknameView
+
+struct RegisterNicknameView_Previews: PreviewProvider {
+    static var previews: some View {
+        RegisterNicknameView()
+    }
+}

--- a/BE/Util/Extension/View.swift
+++ b/BE/Util/Extension/View.swift
@@ -1,0 +1,32 @@
+//
+//  View.swift
+//  BE
+//
+//  Created by Noah's Ark on 2022/07/02.
+//
+//  View 관련 extension을 관리합니다.
+
+import SwiftUI
+
+// TextField의 placeholder 텍스트의 color를 설정합니다.
+/*
+ 사용 예시는 아래와 같습니다. 입력받은 텍스트가 없는 경우 gray color의 placeholder 표시
+ TextField("", text: $description)
+     .font(.system(size: 16, weight: .regular))
+     .placeholder(when: description.isEmpty) {
+             Text(placeholder)
+                 .foregroundColor(.gray)
+     }
+ */
+extension View {
+    func placeholder<Content: View>(
+        when shouldShow: Bool,
+        alignment: Alignment = .leading,
+        @ViewBuilder placeholder: () -> Content) -> some View {
+
+        ZStack(alignment: alignment) {
+            placeholder().opacity(shouldShow ? 1 : 0)
+            self
+        }
+    }
+}


### PR DESCRIPTION
## 작업내용
- Source / Components / TextInputContainer: 회원가입 시 사용자로부터 텍스트 정보를 받기 위한 컴포넌트 
- Source / RegisterNicknameView: 닉네임 입력 뷰 
- Util / Extension / View: placeholder 텍스트의 컬러 설정을 위한 익스텐션

## 고민사항
- TextInputContainer: 닉네임, 전화번호 입력 시 키보드 스타일이 변경되어야 하기에 해당 뷰 선언 시 keyboardType (UIKeyboardType)라는 변수를 통해 타입을 명시하도록 하였습니다. 가령 닉네임과 같은 String은 .default, 전화번호는 .numberPad에 해당합니다.

## 특이사항
- 디자인 기준이 적용되지 않아 차후 개선이 필요합니다.
