### PR TITLE
[Add] OnboardingView, RegisterSessionView / [Refactor] TextInputContainer, RegisterSessionView, Color extension

### DIFF
--- a/BE.xcodeproj/project.pbxproj
+++ b/BE.xcodeproj/project.pbxproj
@@ -13,6 +13,7 @@
 		7A3DF79E28703CB800CCC81A /* OnboardingView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7A3DF79D28703CB800CCC81A /* OnboardingView.swift */; };
 		7A3DF7A028703EAA00CCC81A /* OnboardingTabView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7A3DF79F28703EAA00CCC81A /* OnboardingTabView.swift */; };
 		7A3DF7A2287044DC00CCC81A /* OnboardingLastView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7A3DF7A1287044DC00CCC81A /* OnboardingLastView.swift */; };
+		7A3DF7A428704AFC00CCC81A /* RegisterSessionView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7A3DF7A328704AFC00CCC81A /* RegisterSessionView.swift */; };
 		C089031D2870225800359264 /* Constant.swift in Sources */ = {isa = PBXBuildFile; fileRef = C089031C2870225800359264 /* Constant.swift */; };
 		C08903202870228D00359264 /* LoginManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = C089031F2870228D00359264 /* LoginManager.swift */; };
 		C08903232870230C00359264 /* String.swift in Sources */ = {isa = PBXBuildFile; fileRef = C08903222870230C00359264 /* String.swift */; };
@@ -35,6 +36,7 @@
 		7A3DF79D28703CB800CCC81A /* OnboardingView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OnboardingView.swift; sourceTree = "<group>"; };
 		7A3DF79F28703EAA00CCC81A /* OnboardingTabView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OnboardingTabView.swift; sourceTree = "<group>"; };
 		7A3DF7A1287044DC00CCC81A /* OnboardingLastView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OnboardingLastView.swift; sourceTree = "<group>"; };
+		7A3DF7A328704AFC00CCC81A /* RegisterSessionView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RegisterSessionView.swift; sourceTree = "<group>"; };
 		C089031C2870225800359264 /* Constant.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Constant.swift; sourceTree = "<group>"; };
 		C089031F2870228D00359264 /* LoginManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoginManager.swift; sourceTree = "<group>"; };
 		C08903222870230C00359264 /* String.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = String.swift; sourceTree = "<group>"; };
@@ -102,6 +104,7 @@
 				C089031B2870223000359264 /* Components */,
 				C0E0B0CD287013BC0081DD1F /* ContentView.swift */,
 				7A3DF79928702D0400CCC81A /* RegisterNicknameView.swift */,
+				7A3DF7A328704AFC00CCC81A /* RegisterSessionView.swift */,
 				7A3DF79D28703CB800CCC81A /* OnboardingView.swift */,
 				7A3DF79F28703EAA00CCC81A /* OnboardingTabView.swift */,
 				7A3DF7A1287044DC00CCC81A /* OnboardingLastView.swift */,
@@ -290,6 +293,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				7A3DF7A428704AFC00CCC81A /* RegisterSessionView.swift in Sources */,
 				C08903252870231D00359264 /* DummyModel.swift in Sources */,
 				7A3DF7A028703EAA00CCC81A /* OnboardingTabView.swift in Sources */,
 				C0E0B0CE287013BC0081DD1F /* ContentView.swift in Sources */,

--- a/BE.xcodeproj/project.pbxproj
+++ b/BE.xcodeproj/project.pbxproj
@@ -10,6 +10,9 @@
 		7A3DF798287029FD00CCC81A /* TextInputContainer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7A3DF797287029FD00CCC81A /* TextInputContainer.swift */; };
 		7A3DF79A28702D0500CCC81A /* RegisterNicknameView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7A3DF79928702D0400CCC81A /* RegisterNicknameView.swift */; };
 		7A3DF79C2870308100CCC81A /* View.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7A3DF79B2870308100CCC81A /* View.swift */; };
+		7A3DF79E28703CB800CCC81A /* OnboardingView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7A3DF79D28703CB800CCC81A /* OnboardingView.swift */; };
+		7A3DF7A028703EAA00CCC81A /* OnboardingTabView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7A3DF79F28703EAA00CCC81A /* OnboardingTabView.swift */; };
+		7A3DF7A2287044DC00CCC81A /* OnboardingLastView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7A3DF7A1287044DC00CCC81A /* OnboardingLastView.swift */; };
 		C089031D2870225800359264 /* Constant.swift in Sources */ = {isa = PBXBuildFile; fileRef = C089031C2870225800359264 /* Constant.swift */; };
 		C08903202870228D00359264 /* LoginManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = C089031F2870228D00359264 /* LoginManager.swift */; };
 		C08903232870230C00359264 /* String.swift in Sources */ = {isa = PBXBuildFile; fileRef = C08903222870230C00359264 /* String.swift */; };
@@ -29,6 +32,9 @@
 		7A3DF797287029FD00CCC81A /* TextInputContainer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TextInputContainer.swift; sourceTree = "<group>"; };
 		7A3DF79928702D0400CCC81A /* RegisterNicknameView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RegisterNicknameView.swift; sourceTree = "<group>"; };
 		7A3DF79B2870308100CCC81A /* View.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = View.swift; sourceTree = "<group>"; };
+		7A3DF79D28703CB800CCC81A /* OnboardingView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OnboardingView.swift; sourceTree = "<group>"; };
+		7A3DF79F28703EAA00CCC81A /* OnboardingTabView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OnboardingTabView.swift; sourceTree = "<group>"; };
+		7A3DF7A1287044DC00CCC81A /* OnboardingLastView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OnboardingLastView.swift; sourceTree = "<group>"; };
 		C089031C2870225800359264 /* Constant.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Constant.swift; sourceTree = "<group>"; };
 		C089031F2870228D00359264 /* LoginManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoginManager.swift; sourceTree = "<group>"; };
 		C08903222870230C00359264 /* String.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = String.swift; sourceTree = "<group>"; };
@@ -96,6 +102,9 @@
 				C089031B2870223000359264 /* Components */,
 				C0E0B0CD287013BC0081DD1F /* ContentView.swift */,
 				7A3DF79928702D0400CCC81A /* RegisterNicknameView.swift */,
+				7A3DF79D28703CB800CCC81A /* OnboardingView.swift */,
+				7A3DF79F28703EAA00CCC81A /* OnboardingTabView.swift */,
+				7A3DF7A1287044DC00CCC81A /* OnboardingLastView.swift */,
 			);
 			path = Source;
 			sourceTree = "<group>";
@@ -282,14 +291,17 @@
 			buildActionMask = 2147483647;
 			files = (
 				C08903252870231D00359264 /* DummyModel.swift in Sources */,
+				7A3DF7A028703EAA00CCC81A /* OnboardingTabView.swift in Sources */,
 				C0E0B0CE287013BC0081DD1F /* ContentView.swift in Sources */,
 				7A3DF79C2870308100CCC81A /* View.swift in Sources */,
 				C08903272870233500359264 /* DummyView.swift in Sources */,
 				7A3DF798287029FD00CCC81A /* TextInputContainer.swift in Sources */,
+				7A3DF79E28703CB800CCC81A /* OnboardingView.swift in Sources */,
 				7A3DF79A28702D0500CCC81A /* RegisterNicknameView.swift in Sources */,
 				C08903202870228D00359264 /* LoginManager.swift in Sources */,
 				C08903232870230C00359264 /* String.swift in Sources */,
 				C0E0B0CC287013BC0081DD1F /* BEApp.swift in Sources */,
+				7A3DF7A2287044DC00CCC81A /* OnboardingLastView.swift in Sources */,
 				C089031D2870225800359264 /* Constant.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/BE/Source/Components/TextInputContainer.swift
+++ b/BE/Source/Components/TextInputContainer.swift
@@ -18,35 +18,29 @@ struct TextInputContainer: View {
     @Binding var isCompleted: Bool
     
     var body: some View {
-        VStack {
-            ZStack {
-                VStack (alignment: .leading) {
-                    // 닉네임, 전화번호 등 타이틀을 설정합니다.
-                    Text(title)
-                        .foregroundColor(.red)
-                        .font(.system(size: 16, weight: .medium))
-                    
-                    // 사용자의 텍스트를 입력받습니다.
-                    TextField("", text: $description)
-                        .keyboardType(keyboardType)
-                        .font(.system(size: 22, weight: .regular))
-                        .placeholder(when: description.isEmpty) {
-                            Text(placeholder)
-                                .foregroundColor(.blue)
-                        }
-                        .onSubmit {
-                            self.isCompleted = true
-                        }
+        VStack (alignment: .leading) {
+            // 닉네임, 전화번호 등 타이틀을 설정합니다.
+            Text(title)
+                .foregroundColor(.red)
+                .font(.system(size: 16, weight: .medium))
+            
+            // 사용자의 텍스트를 입력받습니다.
+            TextField("", text: $description)
+                .keyboardType(keyboardType)
+                .font(.system(size: 22, weight: .regular))
+                .placeholder(when: description.isEmpty) {
+                    Text(placeholder)
+                        .foregroundColor(.blue)
                 }
-                .padding(.leading, 14)
-                .padding(.vertical, 15)
-            }// ZStack
-            .background(.gray)
-            .cornerRadius(12)
+                .onSubmit {
+                    self.isCompleted = true
+                }
+
         }// VStack
-        .padding(.horizontal, 20)
-        
-        
+        .padding(.leading, 14)
+        .padding(.vertical, 15)
+        .background(.gray)
+        .cornerRadius(12)
     }// body
 }// TextInputContainer
 

--- a/BE/Source/Components/TextInputContainer.swift
+++ b/BE/Source/Components/TextInputContainer.swift
@@ -21,16 +21,16 @@ struct TextInputContainer: View {
         VStack (alignment: .leading) {
             // 닉네임, 전화번호 등 타이틀을 설정합니다.
             Text(title)
-                .foregroundColor(.red)
-                .font(.system(size: 16, weight: .medium))
+                .foregroundColor(Color.main)
+                .font(.subheadline)
             
             // 사용자의 텍스트를 입력받습니다.
             TextField("", text: $description)
                 .keyboardType(keyboardType)
-                .font(.system(size: 22, weight: .regular))
+                .font(.title2)
                 .placeholder(when: description.isEmpty) {
                     Text(placeholder)
-                        .foregroundColor(.blue)
+                        .foregroundColor(Color.background)
                 }
                 .onSubmit {
                     self.isCompleted = true
@@ -39,7 +39,7 @@ struct TextInputContainer: View {
         }// VStack
         .padding(.leading, 14)
         .padding(.vertical, 15)
-        .background(.gray)
+        .background(Color.background)
         .cornerRadius(12)
     }// body
 }// TextInputContainer

--- a/BE/Source/ContentView.swift
+++ b/BE/Source/ContentView.swift
@@ -8,9 +8,16 @@
 import SwiftUI
 
 struct ContentView: View {
+    
+    //OnBoarding
+    @AppStorage("_isFirstLaunching") var isFirstLaunching: Bool = true
+    
     var body: some View {
         Text("Hello, world!")
             .padding()
+            .fullScreenCover(isPresented: $isFirstLaunching) {
+                OnboardingTabView(isFirstLaunching: $isFirstLaunching)
+            }
     }
 }
 

--- a/BE/Source/ContentView.swift
+++ b/BE/Source/ContentView.swift
@@ -8,8 +8,7 @@
 import SwiftUI
 
 struct ContentView: View {
-    
-    //OnBoarding
+    // OnBoarding
     @AppStorage("_isFirstLaunching") var isFirstLaunching: Bool = true
     
     var body: some View {

--- a/BE/Source/OnboardingLastView.swift
+++ b/BE/Source/OnboardingLastView.swift
@@ -1,0 +1,54 @@
+//
+//  OnboardingLastView.swift
+//  BE
+//
+//  Created by Noah's Ark on 2022/07/02.
+//
+
+import SwiftUI
+
+struct OnboardingLastView: View {
+    
+    @Binding var isFirstLaunching: Bool
+    
+    var body: some View {
+        ZStack {
+            Color.red.ignoresSafeArea()
+            
+            VStack {
+                HStack {
+                    Text("온보딩 마지막 뷰 테스트")
+                        .foregroundColor(.white)
+                        .font(.system(size: 22, weight: .bold))
+                    
+                    Spacer()
+                }// HStack
+                .padding(.horizontal, 20)
+                
+                Spacer()
+                
+                // Onboarding dismiss button
+                Button(action: {
+                    isFirstLaunching.toggle()
+                }) {
+                    Text("텍스트")
+                        .foregroundColor(.white)
+                }
+                
+                Spacer()
+
+            }// VStack
+            .padding(.top, 170)
+            
+        }// ZStack
+    }// body
+}// OnboardingLastView
+
+struct OnboardingLastView_Previews: PreviewProvider {
+
+    @State static var isFirstLaunching: Bool = true
+    
+    static var previews: some View {
+        OnboardingLastView(isFirstLaunching: $isFirstLaunching)
+    }
+}

--- a/BE/Source/OnboardingTabView.swift
+++ b/BE/Source/OnboardingTabView.swift
@@ -1,0 +1,31 @@
+//
+//  OnBoardingTapView.swift
+//  BE
+//
+//  Created by Noah's Ark on 2022/07/02.
+//
+
+import SwiftUI
+
+struct OnboardingTabView: View {
+    
+    @Binding var isFirstLaunching: Bool
+    
+    var body: some View {
+        TabView {
+            OnboardingFirstView()
+            OnboardingLastView(isFirstLaunching: $isFirstLaunching)
+        }
+        .ignoresSafeArea()
+        .tabViewStyle(PageTabViewStyle())
+    }
+}
+
+struct OnboardingTabView_Previews: PreviewProvider {
+
+    @State static var isFirstLaunching = true
+
+    static var previews: some View {
+        OnboardingTabView(isFirstLaunching: $isFirstLaunching)
+    }
+}

--- a/BE/Source/OnboardingView.swift
+++ b/BE/Source/OnboardingView.swift
@@ -1,0 +1,38 @@
+//
+//  OnBoardingView.swift
+//  BE
+//
+//  Created by Noah's Ark on 2022/07/02.
+//
+
+import SwiftUI
+
+struct OnboardingFirstView: View {
+    var body: some View {
+        ZStack {
+            Color.red.ignoresSafeArea()
+            
+            VStack {
+                HStack {
+                    Text("환영합니다.\n\n소개 및 결제방식")
+                        .foregroundColor(.white)
+                        .font(.system(size: 22, weight: .bold))
+                    
+                    Spacer()
+                }// HStack
+                .padding(.horizontal, 20)
+                
+                Spacer()
+
+            }// VStack
+            .padding(.top, 170)
+            
+        }// ZStack
+    }// body
+}// OnBoardingView
+
+struct OnboardingView_Previews: PreviewProvider {
+    static var previews: some View {
+        OnboardingFirstView()
+    }
+}

--- a/BE/Source/RegisterNicknameView.swift
+++ b/BE/Source/RegisterNicknameView.swift
@@ -25,7 +25,6 @@ struct RegisterNicknameView: View {
                     
                     Spacer()
                 }
-                .padding(.horizontal, 20)
                 
                 TextInputContainer(
                     title: title,
@@ -37,11 +36,11 @@ struct RegisterNicknameView: View {
 
                 Spacer()
 
-                NavigationLink(destination: ContentView(), isActive: $isCompleted) {
+                NavigationLink(destination: RegisterSessionView(), isActive: $isCompleted) {
                     EmptyView()
                 }
             }
-
+            .padding(.horizontal, 20)
         }// NavigationView
     }// body
 }// RegisterNicknameView

--- a/BE/Source/RegisterSessionView.swift
+++ b/BE/Source/RegisterSessionView.swift
@@ -1,0 +1,52 @@
+//
+//  RegisterSessionView.swift
+//  BE
+//
+//  Created by Noah's Ark on 2022/07/02.
+//
+
+import SwiftUI
+
+struct RegisterSessionView: View {
+    
+    @State var isCompleted: Bool = false
+    
+    var body: some View {
+        NavigationView {
+            VStack {
+                HStack {
+                    Text("오전/오후반이신가요?")
+                        .font(.system(size: 22, weight: .bold))
+                        .multilineTextAlignment(.leading)
+                    
+                    Spacer()
+                }
+                .padding(.horizontal, 20)
+
+                HStack {
+                    Button(action: {}) {
+                        Text("오전반")
+                    }
+                    
+                    Button(action: {}) {
+                        Text("오후반")
+                    }
+
+                }
+
+                Spacer()
+
+                NavigationLink(destination: ContentView(), isActive: $isCompleted) {
+                    EmptyView()
+                }
+            }
+
+        }// NavigationView
+    }// body
+}// RegisterSessionView
+
+struct RegisterSessionView_Previews: PreviewProvider {
+    static var previews: some View {
+        RegisterSessionView()
+    }
+}

--- a/BE/Source/RegisterSessionView.swift
+++ b/BE/Source/RegisterSessionView.swift
@@ -10,6 +10,7 @@ import SwiftUI
 struct RegisterSessionView: View {
     
     @State var isCompleted: Bool = false
+    @State var selectedSession: String = ""
     
     var body: some View {
         NavigationView {
@@ -21,17 +22,18 @@ struct RegisterSessionView: View {
                     
                     Spacer()
                 }
-                .padding(.horizontal, 20)
 
+                // Session Button Container
                 HStack {
-                    Button(action: {}) {
-                        Text("오전반")
-                    }
+                    SessionSelectionButton(
+                        sessionName: "오전반",
+                        selectedSession: $selectedSession
+                    )
                     
-                    Button(action: {}) {
-                        Text("오후반")
-                    }
-
+                    SessionSelectionButton(
+                        sessionName: "오후반",
+                        selectedSession: $selectedSession
+                    )
                 }
 
                 Spacer()
@@ -39,8 +41,9 @@ struct RegisterSessionView: View {
                 NavigationLink(destination: ContentView(), isActive: $isCompleted) {
                     EmptyView()
                 }
-            }
-
+                
+            }//VStack
+            .padding(.horizontal, 20)
         }// NavigationView
     }// body
 }// RegisterSessionView
@@ -50,3 +53,26 @@ struct RegisterSessionView_Previews: PreviewProvider {
         RegisterSessionView()
     }
 }
+
+// MARK: - 세션 선택 버튼
+struct SessionSelectionButton: View {
+    
+    let sessionName: String
+    
+    @Binding var selectedSession: String
+    
+    var body: some View {
+        Button(action: {
+            selectedSession = sessionName
+        }) {
+            Text(sessionName)
+                .font(.system(size: 18, weight: .semibold))
+                .foregroundColor(.white)
+                .padding(.vertical, 27)
+                .padding(.horizontal, 56)
+                .background(selectedSession == sessionName ? .red : .gray)
+                .cornerRadius(12)
+        }
+
+    }// body
+}// SessionSelectionButton

--- a/BE/Source/RegisterSessionView.swift
+++ b/BE/Source/RegisterSessionView.swift
@@ -55,7 +55,7 @@ struct RegisterSessionView_Previews: PreviewProvider {
 }
 
 // MARK: - 세션 선택 버튼
-struct SessionSelectionButton: View {
+fileprivate struct SessionSelectionButton: View {
     
     let sessionName: String
     

--- a/BE/Source/RegisterSessionView.swift
+++ b/BE/Source/RegisterSessionView.swift
@@ -66,11 +66,11 @@ struct SessionSelectionButton: View {
             selectedSession = sessionName
         }) {
             Text(sessionName)
-                .font(.system(size: 18, weight: .semibold))
-                .foregroundColor(.white)
+                .font(.headline)
+                .foregroundColor(selectedSession == sessionName ? Color.background : Color.container)
                 .padding(.vertical, 27)
                 .padding(.horizontal, 56)
-                .background(selectedSession == sessionName ? .red : .gray)
+                .background(selectedSession == sessionName ? Color.main : Color.background)
                 .cornerRadius(12)
         }
 


### PR DESCRIPTION
## 작업내용
1. OnboardingView Basic Setting
 - 온보딩 뷰 기본 템플릿 구현했습니다. ContentView 파일과 연결되어 있습니다.

<img width="325" alt="image" src="https://user-images.githubusercontent.com/88080251/176997174-03700798-1b54-4311-b2a9-423358a2a277.png">

2. RegisterSessionView / RegisterNicknameView
 - 세션 선택을 위한 버튼 뷰 구현했습니다. 해당 뷰는 RegisterNicknameView 이후 단계로 설정되었습니다.
 
<img width="330" alt="image" src="https://user-images.githubusercontent.com/88080251/176997200-1dda0869-9979-40d0-9ff6-7e122d90b094.png">

3. 리팩토링
- TextInputContainer : 기존 파일 안에서 설정되었던 padding을 삭제했습니다. 해당 컨테이너가 선언되는 뷰에서 자체적으로 패딩 설정이 필요합니다. (@Apple-Kong)
- RegisterSessionView : 반복적으로 사용되는 세션 버튼을 subview로 대체하였습니다.
- Color extension: 메인 컬러에 맞게 디자인 개선하였습니다.

