### PR TITLE
[Feat] 장바구니 메뉴 수량 수정 기능 추가

### DIFF
--- a/BE.xcodeproj/project.pbxproj
+++ b/BE.xcodeproj/project.pbxproj
@@ -7,7 +7,6 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
-		37B042082875E32F0043E9CB /* Secret.swift in Sources */ = {isa = PBXBuildFile; fileRef = 37B042072875E32F0043E9CB /* Secret.swift */; };
 		7A0AD46E2870A8C500F81DBE /* CartView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7A0AD46D2870A8C500F81DBE /* CartView.swift */; };
 		7A0AD4702870AABB00F81DBE /* MenuTitle.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7A0AD46F2870AABB00F81DBE /* MenuTitle.swift */; };
 		7A0AD4722870AB5400F81DBE /* BackgroundRectangle.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7A0AD4712870AB5400F81DBE /* BackgroundRectangle.swift */; };
@@ -22,6 +21,7 @@
 		7A3DF7A028703EAA00CCC81A /* OnboardingTabView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7A3DF79F28703EAA00CCC81A /* OnboardingTabView.swift */; };
 		7A3DF7A2287044DC00CCC81A /* OnboardingLastView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7A3DF7A1287044DC00CCC81A /* OnboardingLastView.swift */; };
 		7A3DF7A428704AFC00CCC81A /* RegisterSessionView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7A3DF7A328704AFC00CCC81A /* RegisterSessionView.swift */; };
+		7A4FC5E02880933100505A4F /* Secret.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7A4FC5DF2880933100505A4F /* Secret.swift */; };
 		7A63FFE32870C87A00DCBCB9 /* MyOrderView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7A63FFE22870C87A00DCBCB9 /* MyOrderView.swift */; };
 		7A63FFE92870D0D700DCBCB9 /* OnboardingSecondView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7A63FFE82870D0D700DCBCB9 /* OnboardingSecondView.swift */; };
 		7A63FFEB2870E7E200DCBCB9 /* UserModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7A63FFEA2870E7E200DCBCB9 /* UserModel.swift */; };
@@ -29,6 +29,7 @@
 		7A63FFEF2870E97700DCBCB9 /* RestaurantInfo.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7A63FFEE2870E97700DCBCB9 /* RestaurantInfo.swift */; };
 		7A63FFF12870E9BA00DCBCB9 /* MenuModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7A63FFF02870E9BA00DCBCB9 /* MenuModel.swift */; };
 		7A63FFF82870F6D300DCBCB9 /* OrderViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7A63FFF72870F6D300DCBCB9 /* OrderViewModel.swift */; };
+		7AAE0DD7288D9B21004C6CBE /* MenuHistoryView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7AAE0DD6288D9B21004C6CBE /* MenuHistoryView.swift */; };
 		7AB4047C28706D7B0000E192 /* MenuView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7AB4047B28706D7B0000E192 /* MenuView.swift */; };
 		7AB4047E287071D20000E192 /* MenuDetailLink.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7AB4047D287071D20000E192 /* MenuDetailLink.swift */; };
 		7AB40480287079310000E192 /* MenuViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7AB4047F287079310000E192 /* MenuViewModel.swift */; };
@@ -37,7 +38,6 @@
 		7AB40486287095980000E192 /* RadioButtonContainer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7AB40485287095980000E192 /* RadioButtonContainer.swift */; };
 		8924F813287601260075C4D5 /* NavigationUtil.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8924F812287601260075C4D5 /* NavigationUtil.swift */; };
 		B2B33DC628761A2C00844873 /* (null) in Sources */ = {isa = PBXBuildFile; };
-		B2B33DCB28761B8800844873 /* Secret.swift in Sources */ = {isa = PBXBuildFile; fileRef = B2B33DCA28761B8800844873 /* Secret.swift */; };
 		B2B33DCD28761C0700844873 /* PickerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B2B33DCC28761C0700844873 /* PickerView.swift */; };
 		C033B7DB287058D600ABED90 /* VerificationCodeView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C033B7DA287058D600ABED90 /* VerificationCodeView.swift */; };
 		C033B7DD28706DFB00ABED90 /* VerificationViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = C033B7DC28706DFB00ABED90 /* VerificationViewModel.swift */; };
@@ -60,7 +60,6 @@
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
-		37B042072875E32F0043E9CB /* Secret.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Secret.swift; sourceTree = "<group>"; };
 		6AC41999BD864A6334FDBEAA /* Pods-BE.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-BE.release.xcconfig"; path = "Target Support Files/Pods-BE/Pods-BE.release.xcconfig"; sourceTree = "<group>"; };
 		7183E9D455D84C6700905EBA /* Pods_BE.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_BE.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		7A0AD46D2870A8C500F81DBE /* CartView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CartView.swift; sourceTree = "<group>"; };
@@ -77,6 +76,7 @@
 		7A3DF79F28703EAA00CCC81A /* OnboardingTabView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OnboardingTabView.swift; sourceTree = "<group>"; };
 		7A3DF7A1287044DC00CCC81A /* OnboardingLastView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OnboardingLastView.swift; sourceTree = "<group>"; };
 		7A3DF7A328704AFC00CCC81A /* RegisterSessionView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RegisterSessionView.swift; sourceTree = "<group>"; };
+		7A4FC5DF2880933100505A4F /* Secret.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Secret.swift; sourceTree = "<group>"; };
 		7A63FFE22870C87A00DCBCB9 /* MyOrderView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MyOrderView.swift; sourceTree = "<group>"; };
 		7A63FFE82870D0D700DCBCB9 /* OnboardingSecondView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OnboardingSecondView.swift; sourceTree = "<group>"; };
 		7A63FFEA2870E7E200DCBCB9 /* UserModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserModel.swift; sourceTree = "<group>"; };
@@ -84,6 +84,7 @@
 		7A63FFEE2870E97700DCBCB9 /* RestaurantInfo.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RestaurantInfo.swift; sourceTree = "<group>"; };
 		7A63FFF02870E9BA00DCBCB9 /* MenuModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MenuModel.swift; sourceTree = "<group>"; };
 		7A63FFF72870F6D300DCBCB9 /* OrderViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OrderViewModel.swift; sourceTree = "<group>"; };
+		7AAE0DD6288D9B21004C6CBE /* MenuHistoryView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MenuHistoryView.swift; sourceTree = "<group>"; };
 		7AB4047B28706D7B0000E192 /* MenuView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MenuView.swift; sourceTree = "<group>"; };
 		7AB4047D287071D20000E192 /* MenuDetailLink.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MenuDetailLink.swift; sourceTree = "<group>"; };
 		7AB4047F287079310000E192 /* MenuViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MenuViewModel.swift; sourceTree = "<group>"; };
@@ -91,7 +92,6 @@
 		7AB4048328708D450000E192 /* UpperToolbar.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UpperToolbar.swift; sourceTree = "<group>"; };
 		7AB40485287095980000E192 /* RadioButtonContainer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RadioButtonContainer.swift; sourceTree = "<group>"; };
 		8924F812287601260075C4D5 /* NavigationUtil.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NavigationUtil.swift; sourceTree = "<group>"; };
-		B2B33DCA28761B8800844873 /* Secret.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Secret.swift; sourceTree = "<group>"; };
 		B2B33DCC28761C0700844873 /* PickerView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PickerView.swift; sourceTree = "<group>"; };
 		C033B7DA287058D600ABED90 /* VerificationCodeView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VerificationCodeView.swift; sourceTree = "<group>"; };
 		C033B7DC28706DFB00ABED90 /* VerificationViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VerificationViewModel.swift; sourceTree = "<group>"; };
@@ -139,7 +139,7 @@
 		B2B33DC928761B7F00844873 /* Secrets */ = {
 			isa = PBXGroup;
 			children = (
-				B2B33DCA28761B8800844873 /* Secret.swift */,
+				7A4FC5DF2880933100505A4F /* Secret.swift */,
 			);
 			path = Secrets;
 			sourceTree = "<group>";
@@ -151,13 +151,6 @@
 				6AC41999BD864A6334FDBEAA /* Pods-BE.release.xcconfig */,
 			);
 			path = Pods;
-			sourceTree = "<group>";
-		};
-		C07F9D062870B94800F0777B /* Secrets */ = {
-			isa = PBXGroup;
-			children = (
-			);
-			path = Secrets;
 			sourceTree = "<group>";
 		};
 		C0890318287021F200359264 /* Util */ = {
@@ -201,7 +194,6 @@
 				7A3DF79D28703CB800CCC81A /* OnboardingFirstView.swift */,
 				7A3DF79F28703EAA00CCC81A /* OnboardingTabView.swift */,
 				7A3DF7A1287044DC00CCC81A /* OnboardingLastView.swift */,
-				B26C81C32875F93200CDF4C0 /* PickerView.swift */,
 				7AB4047B28706D7B0000E192 /* MenuView.swift */,
 				7AB4047F287079310000E192 /* MenuViewModel.swift */,
 				7AB4048128708C6D0000E192 /* MenuDetailView.swift */,
@@ -223,6 +215,7 @@
 				7A0AD4732870AC8200F81DBE /* MenuReviewContainer.swift */,
 				7A0AD4752870B1E300F81DBE /* CustomStepper.swift */,
 				7A0AD4772870B48200F81DBE /* LongBottomButton.swift */,
+				7AAE0DD6288D9B21004C6CBE /* MenuHistoryView.swift */,
 			);
 			path = Components;
 			sourceTree = "<group>";
@@ -419,12 +412,10 @@
 				7A0AD4762870B1E300F81DBE /* CustomStepper.swift in Sources */,
 				7AB4047C28706D7B0000E192 /* MenuView.swift in Sources */,
 				7AB4048428708D450000E192 /* UpperToolbar.swift in Sources */,
-				B2B33DCB28761B8800844873 /* Secret.swift in Sources */,
 				B2B33DC628761A2C00844873 /* (null) in Sources */,
 				C0E0B0CE287013BC0081DD1F /* ContentView.swift in Sources */,
 				C033B7DF2870744700ABED90 /* VerificationCodeViewModel.swift in Sources */,
 				7A3DF79C2870308100CCC81A /* View.swift in Sources */,
-				37B042082875E32F0043E9CB /* Secret.swift in Sources */,
 				7AB40486287095980000E192 /* RadioButtonContainer.swift in Sources */,
 				B2B33DCD28761C0700844873 /* PickerView.swift in Sources */,
 				8924F813287601260075C4D5 /* NavigationUtil.swift in Sources */,
@@ -444,10 +435,10 @@
 				C033B7DD28706DFB00ABED90 /* VerificationViewModel.swift in Sources */,
 				C08903232870230C00359264 /* String.swift in Sources */,
 				7A0AD4702870AABB00F81DBE /* MenuTitle.swift in Sources */,
+				7A4FC5E02880933100505A4F /* Secret.swift in Sources */,
 				C089033128704B9F00359264 /* Color.swift in Sources */,
 				C033B7E32870840700ABED90 /* UIViewController.swift in Sources */,
 				C0E0B0CC287013BC0081DD1F /* BEApp.swift in Sources */,
-				B26C81C42875F93200CDF4C0 /* PickerView.swift in Sources */,
 				7A63FFF82870F6D300DCBCB9 /* OrderViewModel.swift in Sources */,
 				7A3DF7A2287044DC00CCC81A /* OnboardingLastView.swift in Sources */,
 				7AB4047E287071D20000E192 /* MenuDetailLink.swift in Sources */,
@@ -456,6 +447,7 @@
 				7A63FFF12870E9BA00DCBCB9 /* MenuModel.swift in Sources */,
 				7A63FFEB2870E7E200DCBCB9 /* UserModel.swift in Sources */,
 				7A63FFED2870E89500DCBCB9 /* OrderModel.swift in Sources */,
+				7AAE0DD7288D9B21004C6CBE /* MenuHistoryView.swift in Sources */,
 				C089032B287038D500359264 /* VerificationView.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/BE/Networking/OrderManager.swift
+++ b/BE/Networking/OrderManager.swift
@@ -86,6 +86,17 @@ class OrderManager: ObservableObject {
     func fetchSelectedMenues() -> [String] { return self.selectedMenues }
     
     func clearSelectedMenues() { return self.selectedMenues.removeAll() }
+    
+    func updateSelectedMenuQuantity(menuName: String, newOrder: [String]) {
+        var filteredArray = self.selectedMenues.filter { (item) -> Bool in
+            return !item.contains(menuName)
+        }
+        
+        filteredArray.append(contentsOf: newOrder)
+
+        clearSelectedMenues()
+        addMenu(menus: filteredArray)        
+    }
 
     func fetchCountPerMenues() -> [MenuItem] {
         var original = MenuItem(name: .original, quantity: 0)

--- a/BE/Networking/OrderManager.swift
+++ b/BE/Networking/OrderManager.swift
@@ -41,6 +41,7 @@ class OrderManager: ObservableObject {
     private init() { }
 
     @Published private var selectedMenues: [String] = []
+    @Published private var orderHistory: [String] = []
     @Published private var orderAvailable: Bool = false
     
     func fetchOrderAvailable() -> Bool { return self.orderAvailable }    
@@ -84,9 +85,11 @@ class OrderManager: ObservableObject {
     func fetchSelectedMenuesCount() -> Int { return self.selectedMenues.count }
 
     func fetchSelectedMenues() -> [String] { return self.selectedMenues }
-    
+
     func clearSelectedMenues() { return self.selectedMenues.removeAll() }
-    
+
+    func createOrderHistory() { self.orderHistory = self.selectedMenues }
+        
     func updateSelectedMenuQuantity(menuName: String, newOrder: [String]) {
         var filteredArray = self.selectedMenues.filter { (item) -> Bool in
             return !item.contains(menuName)
@@ -136,6 +139,47 @@ class OrderManager: ObservableObject {
                 original, pepper, soySauce, originalExtra, pepperExtra, soySauceExtra
             ]
         }
+    }
+    
+    func fetchOrderHistory() -> [MenuItem] {
+        var original = MenuItem(name: .original, quantity: 0)
+        var pepper = MenuItem(name: .pepper, quantity: 0)
+        var soySauce = MenuItem(name: .soySauce, quantity: 0)
+        var originalExtra = MenuItem(name: .originalExtra, quantity: 0)
+        var pepperExtra = MenuItem(name: .peperExtra, quantity: 0)
+        var soySauceExtra = MenuItem(name: .soySauceExtra, quantity: 0)
+
+        for item in self.orderHistory {
+            switch item {
+            case ChamMenuName.original.rawValue:
+                original.quantity += 1
+            case ChamMenuName.pepper.rawValue:
+                pepper.quantity += 1
+            case ChamMenuName.soySauce.rawValue:
+                soySauce.quantity += 1
+            case ChamMenuName.originalExtra.rawValue:
+                originalExtra.quantity += 1
+            case ChamMenuName.peperExtra.rawValue:
+                pepperExtra.quantity += 1
+            case ChamMenuName.soySauceExtra.rawValue:
+                soySauceExtra.quantity += 1
+            default:
+                print("==========================")
+                print("fetchOrderHistory Error")
+                print("OrderManger-fetchOrderHistory")
+                print("==========================")
+                return []
+            }
+        }
+
+        if orderHistory.count == 0 {
+            return []
+        } else {
+            return [
+                original, pepper, soySauce, originalExtra, pepperExtra, soySauceExtra
+            ]
+        }
+
     }
 
     func requestPickUpUsers(completion: @escaping ([User], Error?) -> Void) {
@@ -229,6 +273,7 @@ class OrderManager: ObservableObject {
             switch response.result {
             case .success(let string):
                 print(string)
+                self.orderHistory = []
             case .failure(let error):
                 print(error.localizedDescription)
             }

--- a/BE/Source/CartView.swift
+++ b/BE/Source/CartView.swift
@@ -10,36 +10,21 @@ import SwiftUI
 struct CartView: View {
     @State var quantity: Int = 0
     @State var isAlertActive: Bool = false
-
-    @State var isFalseAlertActive: Bool = false
-
     @State var isOrderCompleted: Bool = false
+    @State var isFalseAlertActive: Bool = false
+    @State var orderList: [MenuItem] = OrderManager.shared.fetchCountPerMenues()
     
+    let orderManger: OrderManager
     var totalPrice: Int {
         let menus = orderManger.fetchCountPerMenues()
         var temp = 0
         for menu in menus {
             temp += menu.price * menu.quantity
         }
+        
         return temp
     }
 
-    
-    let orderManger: OrderManager
-
-    func processOrder() {
-
-//        orderManger.setOrderAvailable()
-        if !orderManger.fetchOrderAvailable() {
-            orderManger.order()
-            self.isOrderCompleted = true
-        } else {
-            self.isFalseAlertActive = true
-        }
-    }
-    
-    @State var orderList: [MenuItem] = OrderManager.shared.fetchCountPerMenues()
-    
     var body: some View {
         VStack {
             // 상단 툴바
@@ -67,11 +52,10 @@ struct CartView: View {
                         ForEach(orderManger.fetchCountPerMenues(), id: \.self) { item in
                             if item.quantity != 0 {
                                 MenuReviewContainer(
-                                    menu: item.name,
+                                    quantity: item.quantity,
                                     price: item.price,
-                                    quantity: item.quantity
+                                    menu: item.name
                                 )
-
                             }
                         }
                     }
@@ -116,7 +100,7 @@ struct CartView: View {
                         )
                     }
                     
-                    NavigationLink(
+                    NavigationLink (
                         destination:
                             OrderCompletionView()
                                 .navigationBarHidden(true)
@@ -137,11 +121,22 @@ struct CartView: View {
         self.isAlertActive = true
     }
     
+    func processOrder() {
 
+//        orderManger.setOrderAvailable()
+        if !orderManger.fetchOrderAvailable() {
+            orderManger.order()
+            self.isOrderCompleted = true
+        } else {
+            self.isFalseAlertActive = true
+        }
+    }
+    
 }// CartView
 
-//struct CartView_Previews: PreviewProvider {
-//    static var previews: some View {
-//        CartView()
-//    }
-//}
+struct CartView_Previews: PreviewProvider {
+    
+    static var previews: some View {
+        CartView(orderManger: OrderManager.shared)
+    }
+}

--- a/BE/Source/Components/CustomStepper.swift
+++ b/BE/Source/Components/CustomStepper.swift
@@ -10,45 +10,41 @@ import SwiftUI
 struct CustomStepper: View {
     
     @Binding var quantity: Int
+    @State var increaseStepper: Bool = false
+    @State var decreaseStepper: Bool = false
     
     var body: some View {
         HStack {
-            Spacer()
-            
-            HStack {
-                Button(action: {
-                    withAnimation {
-                        if self.quantity > 0 {
-                            self.quantity = self.quantity - 1
-                        } else {
-                            self.quantity = 0
-                        }
+            Button(action: {
+                withAnimation {
+                    self.decreaseStepper = true
+                    if self.quantity > 0 {
+                        self.quantity = self.quantity - 1
+                    } else {
+                        self.quantity = 0
                     }
-                }) {
-                    Image(systemName: "minus.square")
-                        .foregroundColor(Color.container)
-                        .transition(.opacity)
-                        .font(.title3)
                 }
-                
-                Text("\(self.quantity)")
-                    .padding(.horizontal, 15)
-                
-                Button(action: {
-                    withAnimation {
-                        self.quantity = self.quantity + 1
-                    }
-                }) {
-                    Image(systemName: "plus.square")
-                        .foregroundColor(Color.container)
-                        .transition(.opacity)
-                        .font(.title3)
-                }
+            }) {
+                ExtractedView(
+                    trigger: $decreaseStepper,
+                    iconName: "minus.square"
+                )
             }
-            .padding(.vertical, 18)
-            .padding(.horizontal, 20)
-            .background(.white)
-            .cornerRadius(10)
+            
+            Text("\(self.quantity)")
+                .padding(.horizontal, 15)
+            
+            Button(action: {
+                withAnimation {
+                    self.increaseStepper = true
+                    self.quantity = self.quantity + 1
+                }
+            }) {
+                ExtractedView(
+                    trigger: $increaseStepper,
+                    iconName: "plus.square"
+                )
+            }
         }
     }
 }
@@ -56,5 +52,26 @@ struct CustomStepper: View {
 struct CustomStepper_Previews: PreviewProvider {
     static var previews: some View {
         CustomStepper(quantity: .constant(0))
+    }
+}
+
+fileprivate struct ExtractedView: View {
+    @Binding var trigger: Bool
+    let iconName: String
+    
+    var body: some View {
+        Image(systemName: trigger ? "\(iconName).fill" : iconName)
+            .transition(.opacity)
+            .font(.title3)
+            .foregroundColor(trigger ? Color.main : Color.container)
+            .onChange(of: trigger) { newValue in
+                if newValue == true {
+                    DispatchQueue.main.asyncAfter(deadline: .now() + 0.25) {
+                        withAnimation {
+                            self.trigger.toggle()
+                        }
+                    }
+                }
+            }
     }
 }

--- a/BE/Source/Components/MenuHistoryView.swift
+++ b/BE/Source/Components/MenuHistoryView.swift
@@ -1,0 +1,57 @@
+//
+//  MenuHistoryView.swift
+//  BE
+//
+//  Created by Noah's Ark on 2022/07/25.
+//
+
+import SwiftUI
+
+struct MenuHistoryView: View {
+    @State var quantity: Int
+
+    let price: Int
+    let menu: String
+    var orderManager = OrderManager.shared
+
+    var body: some View {
+        VStack {
+            HStack {
+                Text(menu)
+                    .font(.headline)
+
+                Spacer()                
+            }
+            
+            HStack {
+                Text("\(price * quantity)" + "원")
+                
+                Spacer()
+            }
+            .padding(.top, 16)
+        }
+        .padding(.vertical, 17)
+        .padding(.horizontal, 15)
+        .background(.white)
+        .cornerRadius(10)
+        .onChange(of: quantity) { newValue in
+            var newProductArray: [String] = []
+
+            for _ in (0..<newValue) {
+                newProductArray.append(menu)
+            }
+            orderManager.updateSelectedMenuQuantity(menuName: menu, newOrder: newProductArray)
+        }
+        
+    }// body
+}// MenuHistoryView
+
+struct MenuHistoryView_Previews: PreviewProvider {
+    static var previews: some View {
+        MenuHistoryView(
+            quantity: 10,
+            price: 5000,
+            menu: "닭갈비덮밥"
+        )
+    }
+}

--- a/BE/Source/Components/MenuReviewContainer.swift
+++ b/BE/Source/Components/MenuReviewContainer.swift
@@ -22,7 +22,7 @@ struct MenuReviewContainer: View {
 
                 Spacer()
                 
-                Button(action: {}) {
+                Button(action: { self.quantity = 0 }) {
                     Image(systemName: "multiply")
                         .foregroundColor(.gray)
                 }
@@ -57,7 +57,7 @@ struct MenuReviewContainer_Previews: PreviewProvider {
         MenuReviewContainer(
             quantity: 10,
             price: 5000,
-            menu: "삼겹살"
+            menu: "닭갈비덮밥"
         )
     }
 }

--- a/BE/Source/Components/MenuReviewContainer.swift
+++ b/BE/Source/Components/MenuReviewContainer.swift
@@ -21,6 +21,11 @@ struct MenuReviewContainer: View {
                     .font(.headline)
 
                 Spacer()
+                
+                Button(action: {}) {
+                    Image(systemName: "multiply")
+                        .foregroundColor(.gray)
+                }
             }
             
             HStack {
@@ -30,9 +35,10 @@ struct MenuReviewContainer: View {
                 
                 CustomStepper(quantity: $quantity)
             }
+            .padding(.top, 16)
         }
         .padding(.vertical, 17)
-        .padding(.horizontal, 16)
+        .padding(.horizontal, 15)
         .background(.white)
         .cornerRadius(10)
         .onChange(of: quantity) { newValue in

--- a/BE/Source/Components/MenuReviewContainer.swift
+++ b/BE/Source/Components/MenuReviewContainer.swift
@@ -8,11 +8,12 @@
 import SwiftUI
 
 struct MenuReviewContainer: View {
+    @State var quantity: Int
 
-    let menu: String
     let price: Int
-    let quantity: Int
-    
+    let menu: String
+    var orderManager = OrderManager.shared
+
     var body: some View {
         VStack {
             HStack {
@@ -27,22 +28,30 @@ struct MenuReviewContainer: View {
                 
                 Spacer()
                 
-                Text("\(quantity)")
+                CustomStepper(quantity: $quantity)
             }
         }
         .padding(.vertical, 17)
         .padding(.horizontal, 16)
         .background(.white)
         .cornerRadius(10)
+        .onChange(of: quantity) { newValue in
+            var newProductArray: [String] = []
+
+            for _ in (0..<newValue) {
+                newProductArray.append(menu)
+            }
+            orderManager.updateSelectedMenuQuantity(menuName: menu, newOrder: newProductArray)
+        }
     }
 }
 
 struct MenuReviewContainer_Previews: PreviewProvider {
     static var previews: some View {
         MenuReviewContainer(
-            menu: "삼겹살",
+            quantity: 10,
             price: 5000,
-            quantity: 10
+            menu: "삼겹살"
         )
     }
 }

--- a/BE/Source/Components/UpperToolbar.swift
+++ b/BE/Source/Components/UpperToolbar.swift
@@ -8,7 +8,6 @@
 import SwiftUI
 
 struct UpperToolbar: View {
-    
     @ObservedObject var menuViewModel: MenuViewModel = MenuViewModel()
     @Environment(\.presentationMode) var presentationMode
     

--- a/BE/Source/MenuDetailView.swift
+++ b/BE/Source/MenuDetailView.swift
@@ -20,11 +20,11 @@ struct MenuDetailView: View {
         for _ in (0..<quantity) {
             orderItemArray.append(menuModel.menu)
         }
-
+        
         OrderManager.shared.addMenu(menus: orderItemArray)
         
         presentationMode.wrappedValue.dismiss()
-
+        
     }
     
     var body: some View {
@@ -71,18 +71,26 @@ struct MenuDetailView: View {
                             .onChange(of: quantity) { newValue in
                                 self.totalCost = newValue * menuModel.price
                             }
+                            .padding(.vertical, 18)
+                            .padding(.horizontal, 20)
+                            .background(.white)
+                            .cornerRadius(10)
+                        
                     }
-                    .padding(.horizontal, 24)
+                    .padding(.leading, 23)
+                    .padding(.trailing, 21)
                     
                     HStack {
                         Text("총 주문금액")
                             .font(.title3)
-                        
+                            .foregroundColor(.gray)
                         Spacer()
                         
                         Text("\(totalCost)" + " 원")
+                            .foregroundColor(.gray)
                     }
-                    .padding(.horizontal, 24)
+                    .padding(.top, 18)
+                    .padding(.horizontal, 23)
                     
                     Spacer()
                     

--- a/BE/Source/MenuView.swift
+++ b/BE/Source/MenuView.swift
@@ -10,6 +10,7 @@ import SwiftUI
 struct MenuView: View {
     @StateObject var orderManager: OrderManager = OrderManager.shared
     @AppStorage("_isFirstLaunching") var isFirstLaunching: Bool = true
+    @State var popToRoot: Bool = false
     @State var isShowFullModal: Bool = true {
         didSet {
             isFirstLaunching = isShowFullModal
@@ -20,9 +21,6 @@ struct MenuView: View {
             showPicekrView = !OrderManager.shared.fetchOrderAvailable()
         }
     }
-    
-    @State var popToRoot: Bool = false
-    
     var menuList = [
         MenuModel(menu: .original, price: .normal),
         MenuModel(menu: .originalExtra, price: .extra),
@@ -105,50 +103,57 @@ struct MenuView: View {
             }// VStack
             .background(Color.main)
             .navigationBarTitleDisplayMode(.inline)
+            .toolbar {
+                NavigationLink(destination: MyOrderView().navigationTitle("MY애점")) {
+                    Image(systemName: "person.fill")
+                        .font(.title3)
+                        .foregroundColor(.white)
+                }
+                
+            }// NavigationView
+            .fullScreenCover(isPresented: $isShowFullModal) {
+                OnboardingTabView(isFirstLaunching: $isShowFullModal)
+            }
+            .fullScreenCover(isPresented: $showPicekrView) {
+                
+            }
+            .accentColor(.white)
             
-        }// NavigationView
-        .fullScreenCover(isPresented: $isShowFullModal) {
-            OnboardingTabView(isFirstLaunching: $isShowFullModal)
-        }
-        .fullScreenCover(isPresented: $showPicekrView) {
-            
-        }
-        .accentColor(.white)
-        .navigationTitle("")
-    }// body
-}// MenuView
-
-struct MenuView_Previews: PreviewProvider {
-    static var previews: some View {
-        MenuView()
-    }
-}
-
-struct CartButton: View {
-    let quantity: Int
+        }// body
+    }// MenuView
     
-    var body: some View {
-        ZStack {
-            RoundedRectangle(cornerRadius: 10)
-                .foregroundColor(.main)
-                .frame(maxWidth: 65, maxHeight: 65)
-            
-            Image(systemName: "cart.fill")
-                .foregroundColor(.background)
-                .font(.largeTitle)
-            
+    struct MenuView_Previews: PreviewProvider {
+        static var previews: some View {
+            MenuView()
+        }
+    }
+    
+    struct CartButton: View {
+        let quantity: Int
+        
+        var body: some View {
             ZStack {
-                Circle()
-                    .foregroundColor(.background)
-                    .frame(maxWidth: 25, maxHeight: 25)
-                    .padding(.leading, 30)
-                    .padding(.bottom, 25)
-                
-                Text("\(quantity)")
+                RoundedRectangle(cornerRadius: 10)
                     .foregroundColor(.main)
-                    .padding(.leading, 30)
-                    .padding(.bottom, 25)
+                    .frame(maxWidth: 65, maxHeight: 65)
                 
+                Image(systemName: "cart.fill")
+                    .foregroundColor(.background)
+                    .font(.largeTitle)
+                
+                ZStack {
+                    Circle()
+                        .foregroundColor(.background)
+                        .frame(maxWidth: 25, maxHeight: 25)
+                        .padding(.leading, 30)
+                        .padding(.bottom, 25)
+                    
+                    Text("\(quantity)")
+                        .foregroundColor(.main)
+                        .padding(.leading, 30)
+                        .padding(.bottom, 25)
+                    
+                }
             }
         }
     }

--- a/BE/Source/MyOrderView.swift
+++ b/BE/Source/MyOrderView.swift
@@ -46,7 +46,7 @@ struct MyOrderView: View {
                     ScrollView {
                         ForEach(orderManger.fetchOrderHistory(), id: \.self) { item in
                             if item.quantity != 0 {
-                                MenuReviewContainer(
+                                MenuHistoryView(
                                     quantity: item.quantity,
                                     price: item.price,
                                     menu: item.name

--- a/BE/Source/MyOrderView.swift
+++ b/BE/Source/MyOrderView.swift
@@ -8,17 +8,23 @@
 import SwiftUI
 
 struct MyOrderView: View {
-    
     @State var showAlert: Bool = false
+    @Environment(\.presentationMode) var presentationMode
+    let orderManger = OrderManager.shared
+    var totalPrice: Int {
+        let menus = orderManger.fetchOrderHistory()
+        var temp = 0
+        for menu in menus {
+            temp += menu.price * menu.quantity
+        }
+        
+        return temp
+    }
     
     var body: some View {
-        VStack {
-            Text("MY애점")
-                .foregroundColor(.white)
-            
+        VStack {            
             ZStack {
                 BackgroundRectangle()
-                
                 
                 VStack {
                     HStack {
@@ -37,39 +43,23 @@ struct MyOrderView: View {
                     .foregroundColor(Color.main)
                     .font(.headline)
                     
-                    VStack (spacing: 0) {
-                        HStack {
-                            Text("삼겹살")
-                            
-                            Spacer()
-                            
-                            Text("1")
-                            
-                            Spacer()
-                            
-                            Text("6,500원")
+                    ScrollView {
+                        ForEach(orderManger.fetchOrderHistory(), id: \.self) { item in
+                            if item.quantity != 0 {
+                                MenuReviewContainer(
+                                    quantity: item.quantity,
+                                    price: item.price,
+                                    menu: item.name
+                                )
+                            }
                         }
-                        .padding(17)
                         
-                        HStack {
-                            Text("삼겹살")
-                            
-                            Spacer()
-                            
-                            Text("1")
-                            
-                            Spacer()
-                            
-                            Text("6,500원")
-                        }
-                        .padding(17)
-
                         HStack {
                             Text("총 주문금액")
                             
                             Spacer()
                             
-                            Text("12,000원")
+                            Text("\(totalPrice)")
                         }
                         .padding(17)
                     }
@@ -87,18 +77,21 @@ struct MyOrderView: View {
                             title: Text("주문취소"),
                             message: Text("정말 주문을 취소하시겠습니까? 취소 시 식사를 배달 받으실 수 있습니다."),
                             primaryButton: .default(
-                                Text("취소"),
+                                Text("뒤로가기"),
                                 action: { }
                             ),
                             secondaryButton: .destructive(
-                                Text("확인"),
-                                action: { }
+                                Text("주문취소"),
+                                action: {
+                                    orderManger.cancellOrder()
+                                    presentationMode.wrappedValue.dismiss()
+                                }
                             )
                         )
                     }
                 }
                 .padding(.horizontal, 20)
-
+                
             }// ZStack
             
         }// VStack

--- a/BE/Source/OrderCompletionView.swift
+++ b/BE/Source/OrderCompletionView.swift
@@ -9,7 +9,6 @@ import SwiftUI
 import UniformTypeIdentifiers
 
 struct OrderCompletionView: View {
-//    @Environment(\.presentationMode) var presentationMode
     @State var orderList : [MenuItem] = OrderManager.shared.fetchCountPerMenues()
     @State var accountNumberAnimation: Bool = true
     @State var isEnabled: Bool = true
@@ -100,7 +99,7 @@ struct OrderCompletionView: View {
                                     
                                     Spacer()
                                     
-                                    Text("\(item.price)")
+                                    Text("\(item.quantity * item.price)원")
                                 }
                                 .padding(17)
                             }
@@ -119,6 +118,7 @@ struct OrderCompletionView: View {
                     backgroundColor: Color.container,
                     action: {
 //                        NavigationUtil.popToRootView()
+                        OrderManager.shared.createOrderHistory()
                         OrderManager.shared.clearSelectedMenues()
                     }
                 )


### PR DESCRIPTION
## 개요

장바구니 내에서 메뉴 수량 조정이 가능하도록 기능을 개선하였습니다.

## PR 타입 (하나 이상의 PR 타입을 선택해주세요)

- [x]  기능 추가
- [ ]  기능 삭제
- [ ]  버그 수정
- [ ]  의존성, 환경 변수, 빌드 관련 코드 업데이트

## 주요 작업 사항

1. Networking / OrderManager
90 - 99 : 수량 변경 시 마다 실행되는 로직입니다. 
<img width="400" alt="image" src="https://user-images.githubusercontent.com/88080251/179054375-c9be4fe0-9275-48dc-9dbb-9daa9da09d51.png">

2. Source / Components / MenuReviewContainer
31 : 스테퍼를 이용하여 수량 변경이 가능하도록 했습니다.
38 - 45 : onChange를 통해 수량이 변경될 때 마다 updateSelectedMenuQuantity 로직이 실행되도록 했습니다.


https://user-images.githubusercontent.com/88080251/179055494-70750927-db74-4bae-a80b-85879f9938b5.mov

